### PR TITLE
fix(domain): corregir método setItems en clase Purchase

### DIFF
--- a/spring-market/src/main/groovy/com/spring_market/domain/Purchase.java
+++ b/spring-market/src/main/groovy/com/spring_market/domain/Purchase.java
@@ -65,6 +65,6 @@ public class Purchase {
     }
 
     public void setItems(List<PurchaseItem> items) {
-        this.items = this.items;
+        this.items = items; // Corrección: usar el parámetro recibido en lugar de this.items porque se asignaba a sí mismo
     }
 }


### PR DESCRIPTION
El método setItems asignaba incorrectamente this.items a sí mismo en lugar de usar el valor del parámetro, causando que items siempre fuera null en las respuestas JSON.